### PR TITLE
Creating compressed docker images

### DIFF
--- a/kuksa-app-publisher/kuksa-publisher.py
+++ b/kuksa-app-publisher/kuksa-publisher.py
@@ -48,7 +48,7 @@ def publish_app(config_file, upload_image=True):
     app_image_file = None
     
     if upload_image:
-        app_image_file = '{}-{}.tar'.format(config['docker']['name'], config['docker']['version'])
+        app_image_file = '{}-{}.tar.bz2'.format(config['docker']['name'], config['docker']['version'])
 
         app_image = config['docker']['image']
         app_image_new = '{}__{}-{}'.format(app_image, config['docker']['name'], config['docker']['version'])
@@ -58,7 +58,7 @@ def publish_app(config_file, upload_image=True):
             print("Failed to re-tag the app image")
             exit(1)
 
-        success = subprocess.run('docker save {} > {}'.format(app_image_new, app_image_file), shell=True).returncode
+        success = subprocess.run('docker save {} | bzip2 -9 > {}'.format(app_image_new, app_image_file), shell=True).returncode
         if success != 0:
             print("Failed to save the docker image")
             exit(1)
@@ -92,7 +92,7 @@ def publish_app(config_file, upload_image=True):
         image_response = http.post(
             url='{}/rest/v1/softwaremodules/{}/artifacts'.format(config['hawkbit']['ip-address'], app_id),
             data={
-                'filename': 'docker-image.tar',
+                'filename': 'docker-image.tar.bz2',
             },
             files={
                 'file': open(app_image_file, mode='rb')


### PR DESCRIPTION
Creating compressed docker images, reducing download times. Goes together with appmanager PR in in-vehicle repo

@rai20 Can you test, if this together with the in-vehicle PR creates images that also work on the target?